### PR TITLE
Add CI to push container image

### DIFF
--- a/.github/workflows/push-image.yml
+++ b/.github/workflows/push-image.yml
@@ -13,9 +13,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
         with:

--- a/.github/workflows/push-image.yml
+++ b/.github/workflows/push-image.yml
@@ -1,0 +1,35 @@
+name: push-image
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build-check:
+    runs-on: ubuntu-latest
+    name: Go build
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          install: true
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1 
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_ROBOT_TOKEN }}
+
+      - name: Build container
+        run: make container
+
+      - name: Push container to registry
+        run: make container-push

--- a/.github/workflows/push-image.yml
+++ b/.github/workflows/push-image.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           install: true
 
-      - name: Login to DockerHub
+      - name: Login to Quay.io
         uses: docker/login-action@v1 
         with:
           registry: quay.io

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ format: $(GOLANGCI_LINT)
 
 .PHONY: go-fmt
 go-fmt: $(GOFUMPT)
-	@fmt_res=$$(gofumpt -l -w $$(find . -type f -name '*.go')); if [ -n "$$fmt_res" ]; then printf '\nGofmt found style issues. Please check the reported issues\nand fix them if necessary before submitting the code for review:\n\n%s' "$$fmt_res"; exit 1; fi
+	@fmt_res=$$($(GOFUMPT) -l -w $$(find . -type f -name '*.go')); if [ -n "$$fmt_res" ]; then printf '\nGofmt found style issues. Please check the reported issues\nand fix them if necessary before submitting the code for review:\n\n%s' "$$fmt_res"; exit 1; fi
 
 .PHONY: lint
 lint: $(GOLANGCI_LINT) go-fmt


### PR DESCRIPTION
This PR adds a GH action that will build and push latest container image to `quay.io/observatorium/rules-objstore` on every merge to `main`.