### PR TITLE
Use default docker build

### DIFF
--- a/.github/workflows/push-image.yml
+++ b/.github/workflows/push-image.yml
@@ -13,11 +13,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-        with:
-          install: true
-
       - name: Login to Quay.io
         uses: docker/login-action@v1 
         with:


### PR DESCRIPTION
The CI to build and push images is currently failing. `make container` is not able to find the image built in previous step. I suspect this is because we are using `buildkit` to build the image.

This PR removes the buildx step and uses default docker build.