### PR TITLE
Instrument service with metrics

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ replace (
 )
 
 require (
-	github.com/efficientgo/e2e v0.11.2-0.20211027134903-67d538984a47
+	github.com/efficientgo/e2e v0.11.2-0.20220316132807-bdd9968326ac
 	github.com/efficientgo/tools/core v0.0.0-20210731122119-5d4a0645ce9a
 	github.com/go-kit/kit v0.11.0
 	github.com/metalmatze/signal v0.0.0-20210307161603-1c9aa721a97a

--- a/go.sum
+++ b/go.sum
@@ -491,8 +491,9 @@ github.com/edsrzf/mmap-go v0.0.0-20170320065105-0bce6a688712/go.mod h1:YO35OhQPt
 github.com/edsrzf/mmap-go v1.0.0 h1:CEBF7HpRnUCSJgGUb5h1Gm7e3VkmVDrR8lvWVLtrOFw=
 github.com/edsrzf/mmap-go v1.0.0/go.mod h1:YO35OhQPt3KJa3ryjFM5Bs14WD66h8eGKpfaBNrHW5M=
 github.com/efficientgo/e2e v0.11.1/go.mod h1:vDnF4AAEZmO0mvyFIATeDJPFaSRM7ywaOnKd61zaSoE=
-github.com/efficientgo/e2e v0.11.2-0.20211027134903-67d538984a47 h1:k0qDUhOU0KJqKztQYJL1qMBR9nCOntuIRWYwA56Z634=
 github.com/efficientgo/e2e v0.11.2-0.20211027134903-67d538984a47/go.mod h1:vDnF4AAEZmO0mvyFIATeDJPFaSRM7ywaOnKd61zaSoE=
+github.com/efficientgo/e2e v0.11.2-0.20220316132807-bdd9968326ac h1:ly9pVwVKeOPH575B5CbMD1jGZMH7CTCYYfBbhEWk5OE=
+github.com/efficientgo/e2e v0.11.2-0.20220316132807-bdd9968326ac/go.mod h1:vDnF4AAEZmO0mvyFIATeDJPFaSRM7ywaOnKd61zaSoE=
 github.com/efficientgo/tools/core v0.0.0-20210129205121-421d0828c9a6/go.mod h1:OmVcnJopJL8d3X3sSXTiypGoUSgFq1aDGmlrdi9dn/M=
 github.com/efficientgo/tools/core v0.0.0-20210201224146-3d78f4d30648/go.mod h1:cFZoHUhKg31xkPnPjhPKFtevnx0Xcg67ptBRxbpaxtk=
 github.com/efficientgo/tools/core v0.0.0-20210731122119-5d4a0645ce9a h1:Az9zRvQubUIHE+tHAm0gG7Dwge08V8Q/9uNSIFjFm+A=

--- a/main.go
+++ b/main.go
@@ -90,7 +90,7 @@ func runRulesObjstore() error {
 		s := http.Server{
 			Addr: cfg.Server.Listen,
 			Handler: rulesspec.Handler(
-				server.NewServer(bkt, log.With(logger, "component", "server")),
+				server.NewServer(bkt, log.With(logger, "component", "server"), reg),
 			),
 		}
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -35,21 +35,25 @@ type Server struct {
 }
 
 func (s *Server) registerServerMetrics(reg *prometheus.Registry) {
+	//nolint:exhaustivestruct
 	s.validations = promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
 		Name: "rules_objstore_validations_total",
 		Help: "Total number of all successful validations for rule files.",
 	}, []string{"tenant"})
 
+	//nolint:exhaustivestruct
 	s.validationFailures = promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
 		Name: "rules_objstore_validation_failures_total",
 		Help: "Total number of all validations for rule files which failed.",
 	}, []string{"tenant"})
 
+	//nolint:exhaustivestruct
 	s.ruleGroupsConfigured = promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
 		Name: "rules_objstore_rule_groups_configured",
 		Help: "Number of Prometheus rule groups configured.",
 	}, []string{"tenant"})
 
+	//nolint:exhaustivestruct
 	s.rulesConfigured = promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
 		Name: "rules_objstore_rules_configured",
 		Help: "Number of Prometheus rules configured.",
@@ -57,11 +61,13 @@ func (s *Server) registerServerMetrics(reg *prometheus.Registry) {
 }
 
 func NewServer(bucket objstore.Bucket, logger log.Logger, reg *prometheus.Registry) *Server {
+	//nolint:exhaustivestruct
 	s := &Server{
 		bucket: bucket,
 		logger: logger,
 	}
 	s.registerServerMetrics(reg)
+
 	return s
 }
 
@@ -108,6 +114,7 @@ func (s *Server) SetRules(w http.ResponseWriter, r *http.Request, tenant string)
 	defer r.Body.Close()
 
 	var groups *rulefmt.RuleGroups
+
 	var errs []error
 	if groups, errs = rulefmt.Parse(data); errs != nil {
 		http.Error(w, "request body failed rule group validation", http.StatusBadRequest)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -12,6 +12,8 @@ import (
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	rulesspec "github.com/observatorium/api/rules"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/prometheus/pkg/rulefmt"
 	"github.com/thanos-io/thanos/pkg/objstore"
 	"gopkg.in/yaml.v3"
@@ -25,13 +27,42 @@ const (
 type Server struct {
 	bucket objstore.Bucket
 	logger log.Logger
+
+	validations          *prometheus.CounterVec
+	validationFailures   *prometheus.CounterVec
+	ruleGroupsConfigured *prometheus.GaugeVec
+	rulesConfigured      *prometheus.GaugeVec
 }
 
-func NewServer(bucket objstore.Bucket, logger log.Logger) *Server {
-	return &Server{
+func (s *Server) registerServerMetrics(reg *prometheus.Registry) {
+	s.validations = promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+		Name: "rules_objstore_validations_total",
+		Help: "Total number of all successful validations for rule files.",
+	}, []string{"tenant"})
+
+	s.validationFailures = promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+		Name: "rules_objstore_validation_failures_total",
+		Help: "Total number of all validations for rule files which failed.",
+	}, []string{"tenant"})
+
+	s.ruleGroupsConfigured = promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
+		Name: "rules_objstore_rule_groups_configured",
+		Help: "Number of Prometheus rule groups configured.",
+	}, []string{"tenant"})
+
+	s.rulesConfigured = promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
+		Name: "rules_objstore_rules_configured",
+		Help: "Number of Prometheus rules configured.",
+	}, []string{"tenant"})
+}
+
+func NewServer(bucket objstore.Bucket, logger log.Logger, reg *prometheus.Registry) *Server {
+	s := &Server{
 		bucket: bucket,
 		logger: logger,
 	}
+	s.registerServerMetrics(reg)
+	return s
 }
 
 // Make sure that Server implements rulesspec.ServerInterface.
@@ -76,12 +107,25 @@ func (s *Server) SetRules(w http.ResponseWriter, r *http.Request, tenant string)
 	}
 	defer r.Body.Close()
 
-	if _, errs := rulefmt.Parse(data); errs != nil {
+	var groups *rulefmt.RuleGroups
+	var errs []error
+	if groups, errs = rulefmt.Parse(data); errs != nil {
 		http.Error(w, "request body failed rule group validation", http.StatusBadRequest)
 		level.Debug(logger).Log("msg", "request body failed rule group validation", "errs", errs)
+		s.validationFailures.WithLabelValues(tenant).Inc()
 
 		return
 	}
+
+	s.validations.WithLabelValues(tenant).Inc()
+	s.ruleGroupsConfigured.WithLabelValues(tenant).Set(float64(len(groups.Groups)))
+
+	rules := 0
+	for _, g := range groups.Groups {
+		rules += len(g.Rules)
+	}
+
+	s.rulesConfigured.WithLabelValues(tenant).Set(float64(rules))
 
 	err = s.bucket.Upload(r.Context(), getRulesFilePath(tenant), bytes.NewReader(data))
 	if err != nil {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -34,41 +34,35 @@ type Server struct {
 	rulesConfigured      *prometheus.GaugeVec
 }
 
-func (s *Server) registerServerMetrics(reg *prometheus.Registry) {
-	//nolint:exhaustivestruct
-	s.validations = promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
-		Name: "rules_objstore_validations_total",
-		Help: "Total number of all successful validations for rule files.",
-	}, []string{"tenant"})
-
-	//nolint:exhaustivestruct
-	s.validationFailures = promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
-		Name: "rules_objstore_validation_failures_total",
-		Help: "Total number of all validations for rule files which failed.",
-	}, []string{"tenant"})
-
-	//nolint:exhaustivestruct
-	s.ruleGroupsConfigured = promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
-		Name: "rules_objstore_rule_groups_configured",
-		Help: "Number of Prometheus rule groups configured.",
-	}, []string{"tenant"})
-
-	//nolint:exhaustivestruct
-	s.rulesConfigured = promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
-		Name: "rules_objstore_rules_configured",
-		Help: "Number of Prometheus rules configured.",
-	}, []string{"tenant"})
-}
-
-func NewServer(bucket objstore.Bucket, logger log.Logger, reg *prometheus.Registry) *Server {
-	//nolint:exhaustivestruct
-	s := &Server{
+func NewServer(bucket objstore.Bucket, logger log.Logger, reg prometheus.Registerer) *Server {
+	return &Server{
 		bucket: bucket,
 		logger: logger,
-	}
-	s.registerServerMetrics(reg)
 
-	return s
+		//nolint:exhaustivestruct
+		validations: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Name: "rules_objstore_validations_total",
+			Help: "Total number of all successful validations for rule files.",
+		}, []string{"tenant"}),
+
+		//nolint:exhaustivestruct
+		validationFailures: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Name: "rules_objstore_validation_failures_total",
+			Help: "Total number of all validations for rule files which failed.",
+		}, []string{"tenant"}),
+
+		//nolint:exhaustivestruct
+		ruleGroupsConfigured: promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
+			Name: "rules_objstore_rule_groups_configured",
+			Help: "Number of Prometheus rule groups configured.",
+		}, []string{"tenant"}),
+
+		//nolint:exhaustivestruct
+		rulesConfigured: promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
+			Name: "rules_objstore_rules_configured",
+			Help: "Number of Prometheus rules configured.",
+		}, []string{"tenant"}),
+	}
 }
 
 // Make sure that Server implements rulesspec.ServerInterface.

--- a/test/e2e/readwrite_test.go
+++ b/test/e2e/readwrite_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/efficientgo/e2e"
+	e2edb "github.com/efficientgo/e2e/db"
 	"github.com/efficientgo/tools/core/pkg/runutil"
 	"github.com/efficientgo/tools/core/pkg/testutil"
 	rulesspec "github.com/observatorium/api/rules"
@@ -90,7 +91,12 @@ func TestRulesReadAndWrite(t *testing.T) {
 
 	prepareConfigs(t, readWrite, e)
 
-	newMinio(t, e)
+	bucket := "obs_rules_test"
+
+	m := e2edb.NewMinio(e, "rules-minio", bucket)
+	testutil.Ok(t, e2e.StartAndWaitReady(m))
+
+	createObjstoreYAML(t, e, bucket, e2edb.MinioAccessKey, e2edb.MinioSecretKey, m.InternalEndpoint(e2edb.AccessPortName))
 
 	rules, err := newRulesObjstoreService(e)
 	testutil.Ok(t, err)

--- a/test/e2e/readwrite_test.go
+++ b/test/e2e/readwrite_test.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	"github.com/efficientgo/e2e"
-	e2edb "github.com/efficientgo/e2e/db"
 	"github.com/efficientgo/tools/core/pkg/runutil"
 	"github.com/efficientgo/tools/core/pkg/testutil"
 	rulesspec "github.com/observatorium/api/rules"
@@ -91,12 +90,7 @@ func TestRulesReadAndWrite(t *testing.T) {
 
 	prepareConfigs(t, readWrite, e)
 
-	bucket := "obs_rules_test"
-
-	m := e2edb.NewMinio(e, "rules-minio", bucket)
-	testutil.Ok(t, e2e.StartAndWaitReady(m))
-
-	createObjstoreYAML(t, e, bucket, e2edb.MinioAccessKey, e2edb.MinioSecretKey, m.InternalEndpoint(e2edb.AccessPortName))
+	newMinio(t, e)
 
 	rules, err := newRulesObjstoreService(e)
 	testutil.Ok(t, err)

--- a/test/e2e/services.go
+++ b/test/e2e/services.go
@@ -4,11 +4,16 @@
 package e2e
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
+	"testing"
 
 	"github.com/efficientgo/e2e"
+	e2edb "github.com/efficientgo/e2e/db"
+	"github.com/efficientgo/tools/core/pkg/testutil"
 )
 
 const (
@@ -40,4 +45,43 @@ func newRulesObjstoreService(e e2e.Environment) (*e2e.InstrumentedRunnable, erro
 			User:      strconv.Itoa(os.Getuid()),
 		},
 	), nil
+}
+
+func newMinio(t *testing.T, e e2e.Environment) {
+	// Create S3 replacement for rules backend
+	bucket := "obs_rules_test"
+	userID := strconv.Itoa(os.Getuid())
+	ports := map[string]int{e2edb.AccessPortName: 8090}
+	envVars := []string{
+		"MINIO_ROOT_USER=" + e2edb.MinioAccessKey,
+		"MINIO_ROOT_PASSWORD=" + e2edb.MinioSecretKey,
+		"MINIO_BROWSER=" + "off",
+		"ENABLE_HTTPS=" + "0",
+		// https://docs.min.io/docs/minio-kms-quickstart-guide.html
+		"MINIO_KMS_KES_ENDPOINT=" + "https://play.min.io:7373",
+		"MINIO_KMS_KES_KEY_FILE=" + "root.key",
+		"MINIO_KMS_KES_CERT_FILE=" + "root.cert",
+		"MINIO_KMS_KES_KEY_NAME=" + "my-minio-key",
+	}
+	f := e2e.NewInstrumentedRunnable(e, "rules-minio", ports, e2edb.AccessPortName)
+	runnable := f.Init(
+		e2e.StartOptions{
+			Image: "minio/minio:RELEASE.2022-03-03T21-21-16Z",
+			// Create the required bucket before starting minio.
+			Command: e2e.NewCommandWithoutEntrypoint("sh", "-c", fmt.Sprintf(
+				// Hacky: Create user that matches ID with host ID to be able to remove .minio.sys details on the start.
+				// Proper solution would be to contribute/create our own minio image which is non root.
+				"useradd -G root -u %v me && mkdir -p %s && chown -R me %s &&"+
+					"curl -sSL --tlsv1.2 -O 'https://raw.githubusercontent.com/minio/kes/master/root.key' -O 'https://raw.githubusercontent.com/minio/kes/master/root.cert' && "+
+					"cp root.* /home/me/ && "+
+					"su - me -s /bin/sh -c 'mkdir -p %s && %s /opt/bin/minio server --address :%v --quiet %v'",
+				userID, f.InternalDir(), f.InternalDir(), filepath.Join(f.InternalDir(), bucket), strings.Join(envVars, " "), ports[e2edb.AccessPortName], f.InternalDir()),
+			),
+			Readiness: e2e.NewHTTPReadinessProbe(e2edb.AccessPortName, "/minio/health/live", 200, 200),
+		},
+	)
+
+	testutil.Ok(t, e2e.StartAndWaitReady(runnable))
+
+	createObjstoreYAML(t, e, bucket, e2edb.MinioAccessKey, e2edb.MinioSecretKey, runnable.InternalEndpoint(e2edb.AccessPortName))
 }

--- a/test/e2e/services.go
+++ b/test/e2e/services.go
@@ -72,7 +72,7 @@ func newMinio(t *testing.T, e e2e.Environment) {
 				// Hacky: Create user that matches ID with host ID to be able to remove .minio.sys details on the start.
 				// Proper solution would be to contribute/create our own minio image which is non root.
 				"useradd -G root -u %v me && mkdir -p %s && chown -R me %s &&"+
-					"curl -sSL --tlsv1.2 -O 'https://raw.githubusercontent.com/minio/kes/master/root.key' -O 'https://raw.githubusercontent.com/minio/kes/master/root.cert' && "+
+					"curl -sSL --tlsv1.3 -O 'https://raw.githubusercontent.com/minio/kes/master/root.key' -O 'https://raw.githubusercontent.com/minio/kes/master/root.cert' && "+
 					"cp root.* /home/me/ && "+
 					"su - me -s /bin/sh -c 'mkdir -p %s && %s /opt/bin/minio server --address :%v --quiet %v'",
 				userID, f.InternalDir(), f.InternalDir(), filepath.Join(f.InternalDir(), bucket), strings.Join(envVars, " "), ports[e2edb.AccessPortName], f.InternalDir()),

--- a/test/e2e/services.go
+++ b/test/e2e/services.go
@@ -4,16 +4,11 @@
 package e2e
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"strconv"
-	"strings"
-	"testing"
 
 	"github.com/efficientgo/e2e"
-	e2edb "github.com/efficientgo/e2e/db"
-	"github.com/efficientgo/tools/core/pkg/testutil"
 )
 
 const (
@@ -23,7 +18,7 @@ const (
 	logLevelDebug = "debug"
 )
 
-func newRulesObjstoreService(e e2e.Environment) (*e2e.InstrumentedRunnable, error) {
+func newRulesObjstoreService(e e2e.Environment) (e2e.InstrumentedRunnable, error) {
 	ports := map[string]int{
 		"http":          8080,
 		"http-internal": 8081,
@@ -37,51 +32,10 @@ func newRulesObjstoreService(e e2e.Environment) (*e2e.InstrumentedRunnable, erro
 		"-log.level":            logLevelDebug,
 	})
 
-	return e2e.NewInstrumentedRunnable(e, "rules_objstore", ports, "http-internal").Init(
-		e2e.StartOptions{
-			Image:     rulesObjstoreImage,
-			Command:   e2e.NewCommandWithoutEntrypoint("rules-objstore", args...),
-			Readiness: e2e.NewHTTPReadinessProbe("http-internal", "/ready", 200, 200),
-			User:      strconv.Itoa(os.Getuid()),
-		},
-	), nil
-}
-
-func newMinio(t *testing.T, e e2e.Environment) {
-	// Create S3 replacement for rules backend
-	bucket := "obs_rules_test"
-	userID := strconv.Itoa(os.Getuid())
-	ports := map[string]int{e2edb.AccessPortName: 8090}
-	envVars := []string{
-		"MINIO_ROOT_USER=" + e2edb.MinioAccessKey,
-		"MINIO_ROOT_PASSWORD=" + e2edb.MinioSecretKey,
-		"MINIO_BROWSER=" + "off",
-		"ENABLE_HTTPS=" + "0",
-		// https://docs.min.io/docs/minio-kms-quickstart-guide.html
-		"MINIO_KMS_KES_ENDPOINT=" + "https://play.min.io:7373",
-		"MINIO_KMS_KES_KEY_FILE=" + "root.key",
-		"MINIO_KMS_KES_CERT_FILE=" + "root.cert",
-		"MINIO_KMS_KES_KEY_NAME=" + "my-minio-key",
-	}
-	f := e2e.NewInstrumentedRunnable(e, "rules-minio", ports, e2edb.AccessPortName)
-	runnable := f.Init(
-		e2e.StartOptions{
-			Image: "minio/minio:RELEASE.2022-03-03T21-21-16Z",
-			// Create the required bucket before starting minio.
-			Command: e2e.NewCommandWithoutEntrypoint("sh", "-c", fmt.Sprintf(
-				// Hacky: Create user that matches ID with host ID to be able to remove .minio.sys details on the start.
-				// Proper solution would be to contribute/create our own minio image which is non root.
-				"useradd -G root -u %v me && mkdir -p %s && chown -R me %s &&"+
-					"curl -sSL --tlsv1.3 -O 'https://raw.githubusercontent.com/minio/kes/master/root.key' -O 'https://raw.githubusercontent.com/minio/kes/master/root.cert' && "+
-					"cp root.* /home/me/ && "+
-					"su - me -s /bin/sh -c 'mkdir -p %s && %s /opt/bin/minio server --address :%v --quiet %v'",
-				userID, f.InternalDir(), f.InternalDir(), filepath.Join(f.InternalDir(), bucket), strings.Join(envVars, " "), ports[e2edb.AccessPortName], f.InternalDir()),
-			),
-			Readiness: e2e.NewHTTPReadinessProbe(e2edb.AccessPortName, "/minio/health/live", 200, 200),
-		},
-	)
-
-	testutil.Ok(t, e2e.StartAndWaitReady(runnable))
-
-	createObjstoreYAML(t, e, bucket, e2edb.MinioAccessKey, e2edb.MinioSecretKey, runnable.InternalEndpoint(e2edb.AccessPortName))
+	return e2e.NewInstrumentedRunnable(e, "rules_objstore").WithPorts(ports, "http-internal").Init(e2e.StartOptions{
+		Image:     rulesObjstoreImage,
+		Command:   e2e.NewCommandWithoutEntrypoint("rules-objstore", args...),
+		Readiness: e2e.NewHTTPReadinessProbe("http-internal", "/ready", 200, 200),
+		User:      strconv.Itoa(os.Getuid()),
+	}), nil
 }


### PR DESCRIPTION
This PR

- Instruments the `rules-objstore` service with the following new metrics, for getting data on validation failure and number of rules configure (object storage bucket operation metrics are already exposed, as we use Thanos `objstore` lib)
```
# HELP rules_objstore_rule_groups_configured Number of Prometheus rule groups configured.
# TYPE rules_objstore_rule_groups_configured gauge
rules_objstore_rule_groups_configured{tenant="oidc-one"} 1
rules_objstore_rule_groups_configured{tenant="oidc-two"} 1
# HELP rules_objstore_rules_configured Number of Prometheus rules configured.
# TYPE rules_objstore_rules_configured gauge
rules_objstore_rules_configured{tenant="oidc-one"} 1
rules_objstore_rules_configured{tenant="oidc-two"} 1
# HELP rules_objstore_validations_total Total number of all successful validations for rule files.
# TYPE rules_objstore_validations_total counter
rules_objstore_validations_total{tenant="oidc-one"} 1
rules_objstore_validations_total{tenant="oidc-two"} 1
```

- Fixes broken e2e test with changes from https://github.com/observatorium/api/pull/251

Fixes #8.

Open question, should there be a counter for all the endpoints like list, listAll and set too?