### PR TITLE
Add support for multi-arch images with docker buildx

### DIFF
--- a/.github/workflows/push-image.yml
+++ b/.github/workflows/push-image.yml
@@ -4,24 +4,49 @@ on:
   push:
     branches:
       - main
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+*"
 
 jobs:
-  build-check:
+  build_push_container:
     runs-on: ubuntu-latest
-    name: Go build
+    name: Build and push the container image for a commit or tag.
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
+      - name: Checkout code into the Go module directory.
+        uses: actions/checkout@v3
 
-      - name: Login to Quay.io
-        uses: docker/login-action@v1 
+      - name: Login to image registry
+        uses: docker/login-action@v2
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_ROBOT_TOKEN }}
 
-      - name: Build container
-        run: make container
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
 
-      - name: Push container to registry
-        run: make container-push
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Cache for Docker's buildx
+        uses: actions/cache@v3
+        with:
+          path: .buildxcache/
+          key: ${{ runner.os }}-buildx-${{ hashFiles('**/*.go', 'Dockerfile', 'go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
+      - name: Snapshot container buid & push
+        run: make conditional-container-build-push
+
+      - name: Check semver tag
+        id: check-semver-tag
+        # The regex below comes from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string.
+        run: |
+          if [[ ${{ github.event.ref }} =~ ^refs/tags/v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$ ]]; then
+              echo ::set-output name=match::true
+          fi
+      - name: Release container build & push
+        if: steps.check-semver-tag.outputs.match == 'true'
+        run: make container-release-build-push

--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ container-build:
 
 .PHONY: container-build-push
 container-build-push:
-	#git update-index --refresh
+	git update-index --refresh
 	@docker buildx build \
 		--push \
 		--platform linux/amd64,linux/arm64 \

--- a/build/conditional-container-push.sh
+++ b/build/conditional-container-push.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+
+usage() {
+    echo "Usage: $0 IMAGE_URI" >&2
+    exit 1
+}
+
+## image_exists_in_repo IMAGE_URI
+#
+# Checks whether IMAGE_URI -- e.g. quay.io/app-sre/osd-metrics-exporter:abcd123
+# -- exists in the remote repository.
+# If so, returns success.
+# If the image does not exist, but the query was otherwise successful, returns
+# failure.
+# If the query fails for any reason, prints an error and *exits* nonzero.
+#
+# This function cribbed from:
+# https://github.com/openshift/boilerplate/blob/0ba6566d544d0df9993a92b2286c131eb61f3e88/boilerplate/_lib/common.sh#L77-L135
+# ...then adapted to use docker rather than skopeo.
+image_exists_in_repo() {
+    local image_uri=$1
+    local output
+    local rc
+    local skopeo_stderr
+
+    skopeo_stderr=$(mktemp)
+    output=$(docker image pull "${image_uri}" 2>"$skopeo_stderr")
+    rc=$?
+    # So we can delete the temp file right away...
+    stderr=$(cat "$skopeo_stderr")
+    rm -f "$skopeo_stderr"
+    if [[ $rc -eq 0 ]]; then
+        # The image exists. Sanity check the output.
+        local report
+        if report=$(docker image inspect "${image_uri}" 2>&1); then
+            local digest
+            digest=$(jq -r '.[].RepoDigests[0]' <<< "$report")
+            if [[ "$digest" != *@* ]]; then
+                echo "Unexpected error: docker inspect succeeded, but output contained no digest."
+                echo "Here's the inspect output:"
+                echo "$report"
+                echo "...and stderr:"
+                echo "$stderr"
+                exit 1
+            fi
+            # Happy path: image exists
+            echo "Image ${image_uri} exists with digest $digest."
+            return 0
+        fi
+        echo "Unexpected error: docker inspect failed after docker pull succeded."
+        echo "Here's the output:"
+        echo "$report"
+        exit 1
+    elif [[ "$stderr" == *"manifest for"*"not found"* ]]; then
+        # We were able to talk to the repository, but the tag doesn't exist.
+        # This is the normal "green field" case.
+        echo "Image ${image_uri} does not exist in the repository."
+        return 1
+    elif [[ "$stderr" == *"was deleted or has expired"* ]]; then
+        # This should be rare, but accounts for cases where we had to
+        # manually delete an image.
+        echo "Image ${image_uri} was deleted from the repository."
+        echo "Proceeding as if it never existed."
+        return 1
+    else
+        # Any other error. For example:
+        #   - "unauthorized: access to the requested resource is not
+        #     authorized". This happens not just on auth errors, but if we
+        #     reference a repository that doesn't exist.
+        #   - "no such host".
+        #   - Network or other infrastructure failures.
+        # In all these cases, we want to bail, because we don't know whether
+        # the image exists (and we'd likely fail to push it anyway).
+        echo "Error querying the repository for ${image_uri}:"
+        echo "stdout: $output"
+        echo "stderr: $stderr"
+        exit 1
+    fi
+}
+
+set -exv
+
+IMAGE_URI=$1
+[[ -z "$IMAGE_URI" ]] && usage
+
+# NOTE(efried): Since we reference images by digest, rebuilding an image
+# with the same tag can be Bad. This is because the digest calculation
+# includes metadata such as date stamp, meaning that even though the
+# contents may be identical, the digest may change. In this situation,
+# the original digest URI no longer has any tags referring to it, so the
+# repository deletes it. This can break existing deployments referring
+# to the old digest. We could have solved this issue by generating a
+# permanent tag tied to each digest. We decided to do it this way
+# instead.
+# For testing purposes, if you need to force the build/push to rerun,
+# delete the image at $IMAGE_URI.
+if image_exists_in_repo "$IMAGE_URI"; then
+    echo "Image ${IMAGE_URI} already exists. Nothing to do!"
+    exit 0
+fi
+
+make container-build-push


### PR DESCRIPTION
Multi-arch support is being added in the same fashion as done in https://github.com/observatorium/up and https://github.com/observatorium/token-refresher. 

I pushed some test images to https://quay.io/repository/douglascamata/rules-obj-store-test?tab=tags and they look good.

**Why migrating this project now?** 

Because I am working towards making the e2e tests of https://github.com/observatorium/api work on Aarch64/arm64 machines and this project is the last dependency that lacks a multi-arch image.

